### PR TITLE
FIX: Allow existing WP user to become a sponsored member

### DIFF
--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -1082,7 +1082,30 @@ function pmprosm_pmpro_after_checkout($user_id)
 					   continue;
 					   
 				$child_user_id = wp_create_user( $child_username[$i], $child_password[$i], $child_email[$i]);
-							
+
+				if( is_wp_error($child_user_id) ) {
+
+					$error_code = $child_user_id->get_error_code();
+
+					switch( $error_code ) {
+						case 'existing_user_email':
+							$existing_user = get_user_by('email', $child_email[$i]);
+							break;
+						case 'existing_user_login':
+							$existing_user = get_user_by('login', $child_username[$i]);
+							break;
+
+						default:
+							$existing_user = null;
+							continue;
+					}
+
+					if(! is_null($existing_user))
+					{
+						$child_user_id = $existing_user->ID;
+					}
+				}
+
 				//update first/last
 				if(!empty($child_first_name[$i]))
 					update_user_meta($child_user_id, "first_name", $child_first_name[$i]);

--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -1086,23 +1086,27 @@ function pmprosm_pmpro_after_checkout($user_id)
 				if( is_wp_error($child_user_id) ) {
 
 					$error_code = $child_user_id->get_error_code();
+					$existing_user = null;
 
-					switch( $error_code ) {
-						case 'existing_user_email':
-							$existing_user = get_user_by('email', $child_email[$i]);
-							break;
-						case 'existing_user_login':
-							$existing_user = get_user_by('login', $child_username[$i]);
-							break;
-
-						default:
-							$existing_user = null;
-							continue;
+					// check the error code & look up user if it's a duplicate email.
+					if ( $error_code == 'existing_user_email' )
+					{
+						$existing_user = get_user_by( 'email', $child_email[ $i ] );
+					}
+					else
+					{
+						// skip this user (quietly). -- TODO: Should probably return message to admin?
+						$existing_user = null;
+						continue;
 					}
 
-					if(! is_null($existing_user))
+					// have an actual WP_User object & is user already a member?
+					if( ! is_null($existing_user) && ! pmpro_getMembershipLevelForUser( $existing_user->ID ) )
 					{
 						$child_user_id = $existing_user->ID;
+					}
+					else {
+						continue;
 					}
 				}
 


### PR DESCRIPTION
If the sponsored user's email address is present in the DB, allow the sponsor add them to their list of sponsored members. If the user's username already exists, then silently skip the new sponsored user.