### PR TITLE
BUG: Fixed PHP array to string warning when...

### DIFF
--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -855,8 +855,12 @@ function pmprosm_pmpro_checkout_boxes()
         $seats = $pmprosm_values['seats'];
 
 	if ($seats == "") $seats = 0; 	// leaving blank ('') causes this to be unlimited.
-
-	$sponsored_level = pmpro_getLevel($pmprosm_values['sponsored_level_id']);
+	
+	if(is_array($pmprosm_values['sponsored_level_id']))
+		$sponsored_level = pmpro_getLevel($pmprosm_values['sponsored_level_id'][0]);
+	else
+		$sponsored_level = pmpro_getLevel($pmprosm_values['sponsored_level_id']);
+		
 	?>
 	<div id="pmpro_extra_seats" class="pmpro_checkout">
 		<hr />


### PR DESCRIPTION
`sponsored_accounts_at_checkout => true` and `sponsored_level_id` is an array.

To recreate the bug use the following settings:

`
global $pmprosm_sponsored_account_levels;
  $pmprosm_sponsored_account_levels = array(
    //seats based on field at checkout
    1 => array(
    	'main_level_id' => 1,
    	'sponsored_level_id' => array(2,3), 
        'min_seats' => 2,
        'max_seats' => 20,
        'seat_cost' => 10,
        'sponsored_accounts_at_checkout' => true,
    	),
  );
`

Fix gets the first `sponsored_level_id` element when `sponsored_level_id` is an array. It is consistent with assigning the first `sponsored_level_id` element membership level to child accounts created at checkout.  See `function pmprosm_pmpro_after_checkout($user_id)` for reference:

https://github.com/strangerstudios/pmpro-sponsored-members/blob/master/pmpro-sponsored-members.php#L1270-L1273 