### PR TITLE
fix for paypal express compatibility

### DIFF
--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -1653,7 +1653,18 @@ function pmprosm_init_load_session_vars($param)
 
 	return $param;
 }
-add_action('init', 'pmprosm_init_load_session_vars', 5);
+add_action('pmpro_checkout_preheader', 'pmprosm_init_load_session_vars', 5);
+
+// add the 'seats' parameter to the Paypal Express return url so we charge the correct amount
+function pmprosm_paypal_express_return_url_parameters( $params )
+{
+	if(isset( $_REQUEST['seats'] ))
+	{
+		$params['seats'] = intval($_REQUEST['seats']);
+	}
+	return $params;
+}
+add_filter("pmpro_paypal_express_return_url_parameters", "pmprosm_paypal_express_return_url_parameters" );
 
 //add code and seats fields to profile for admins
 function pmprosm_profile_fields_seats($user)


### PR DESCRIPTION
Paypal Express compatibility still doesn't appear to work correctly as of the latest version. I tested just the changing 'init' to 'pmpro_checkout_preheader' like in PR #53 [here](https://github.com/strangerstudios/pmpro-sponsored-members/pull/53/commits/d1500f6810b00be0f886281c64d44744bbca67d1#diff-3c44c3277de331084266db39f686d8a2L1656), but that was only partially effective; coupon codes were generated and the correct amount for transactions showed during initial trip to Paypal, but the actual price charged didn't include the extra seat cost. Preserving the 'seats' parameter by including it in NVP string's return URL fixes that.
 
Steps to reproduce:

1. Create a membership level with a $1 initial payment
2. Created a sponsored level that costs $1 per seat with seats chosen at checkout
Example array:
```global $pmprosm_sponsored_account_levels;	
$pmprosm_sponsored_account_levels = array(
		1 => array(
				'main_level_id' => 1
				'sponsored_level_id' => 2,
				'seat_cost' => 1,
				'max_seats' => 100,
				'min_seats' => 1,
		)
);
```
3. Checkout with PayPal Express, choosing 1 seat
4. Complete checkout and go to confirmation page in PMPro
5. No sponsored members created, PMPro order does not reflect extra seat cost
6. Install this PR
7. Repeat steps 3-4
8. Sponsored members created, amount shown during Paypal-side checkout steps, in Orders table, and actual amount charged all match

Fixes:
#44

Tested on:

PMPro v2.0.7 + v2.1 beta 1, Sponsored Members v0.7, WP 5.2.2