### PR TITLE
Allow account creation during checkout for fixed-seat configs

### DIFF
--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -861,13 +861,16 @@ function pmprosm_pmpro_checkout_boxes()
 	//make sure options are defined for this
 	$pmprosm_values = pmprosm_getValuesByMainLevel($pmpro_level->id);
 		
-	if(empty($pmprosm_values['max_seats']) || !isset($pmprosm_values['seat_cost']))
-	{
+	if (
+		( empty( $pmprosm_values['seats'] ) && empty( $pmprosm_values['max_seats'] ) ) ||
+		! isset( $pmprosm_values['seat_cost'] )
+	){
 		return;
 	}
 
+	$can_edit_seats = empty( $pmprosm_values['max_seats'] ) && empty( $pmprosm_values['min_seats'] );
 	$seat_cost = $pmprosm_values['seat_cost'];
-	$max_seats = $pmprosm_values['max_seats'];
+	$max_seats = empty( $pmprosm_values['max_seats'] ) ? null : $pmprosm_values['max_seats'];
 
 	//get seats from submit
 	if(isset($_REQUEST['seats']))
@@ -889,39 +892,56 @@ function pmprosm_pmpro_checkout_boxes()
 		
 	?>
 	<div id="pmpro_extra_seats" class="pmpro_checkout">
-		<hr />
-		<h3>
-			<span class="pmpro_checkout-h3-name">
-                <?php if ($seat_cost > 0) {
-					esc_html_e("Would you like to purchase extra seat(s)?", "pmpro-sponsored-members");
-				} else {
-					esc_html_e("Would you like to create extra account(s)?", "pmpro-sponsored-members");
-				}
+		<?php
+			if ( $can_edit_seats ) {
+		?>
+			<hr />
+			<h3>
+				<span class="pmpro_checkout-h3-name">
+				<?php
+					if ( $seat_cost >  0) {
+						esc_html_e( "Would you like to purchase extra seat(s)?", "pmpro-sponsored-members" );
+					} else {
+						esc_html_e( "Would you like to create extra account(s)?", "pmpro-sponsored-members" );
+					}
 				?>
-            </span>
-		</h3>
+				</span>
+			</h3>
+		<?php } ?>
 		<div class="pmpro_checkout-fields">
 			<div class="pmpro_checkout-field pmpro_checkout-field-seats">
-				<label for="seats"><?php echo __('Number of Seats', 'pmpro-sponsored-members');?></label>
-				<input type="text" id="seats" name="seats" value="<?php echo esc_attr($seats);?>" size="10" />
-				<p class="pmpro_small">
-					<?php
-                        //min seats defaults to 1
-                        if(!empty($pmprosm_values['min_seats']))
-                            $min_seats = $pmprosm_values['min_seats'];
-                        else
-                            $min_seats = 1;
 
-                        if ($max_seats > 1) {
-                            if ( isset( $pmprosm_values['seat_cost_text'] ) ) {
-                                printf( esc_html__( "Enter a number from %d to %d. %s", "pmpro-sponsored-members" ), $min_seats, $pmprosm_values['max_seats'], $pmprosm_values['seat_cost_text'] );
-                            } else {
-                                printf( esc_html__( "Enter a number from %d to %d. +%s per extra seat.", "pmpro-sponsored-members" ), $min_seats, $pmprosm_values['max_seats'], $pmpro_currency_symbol . $pmprosm_values['seat_cost'] );
-                            }
-                        }
-					?>						
-				</p>					
+				<?php
+					if ( $can_edit_seats ) {
+				?>
+						<label for="seats"><?php echo __( 'Number of Seats', 'pmpro-sponsored-members' );?></label>
+						<input type="text" id="seats" name="seats" value="<?php echo esc_attr( $seats ); ?>" size="10" />
+				<?php } else { ?>
+						<input type="hidden" name="seats" value="<?php echo esc_attr( $seats ); ?>" size="10" />
+				<?php } ?>
 
+				<?php
+					if ( $can_edit_seats ) {
+				?>
+						<p class="pmpro_small">
+							<?php
+								//min seats defaults to 1
+								if( ! empty( $pmprosm_values['min_seats'] ) ) {
+									$min_seats = $pmprosm_values['min_seats'];
+								} else {
+									$min_seats = 1;
+								}
+
+								if ( $max_seats > 1 ) {
+									if ( isset( $pmprosm_values['seat_cost_text'] ) ) {
+										printf( esc_html__( "Enter a number from %d to %d. %s", "pmpro-sponsored-members" ), $min_seats, $pmprosm_values['max_seats'], $pmprosm_values['seat_cost_text'] );
+									} else {
+										printf( esc_html__( "Enter a number from %d to %d. +%s per extra seat.", "pmpro-sponsored-members" ), $min_seats, $pmprosm_values['max_seats'], $pmpro_currency_symbol . $pmprosm_values['seat_cost'] );
+									}
+								}
+							?>
+						</p>
+				<?php } ?>
 				<?php
 				//adding sub accounts at checkout?
 				if(!empty($pmprosm_values['sponsored_accounts_at_checkout']))

--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -917,7 +917,7 @@ function pmprosm_pmpro_checkout_boxes()
 						<label for="seats"><?php echo __( 'Number of Seats', 'pmpro-sponsored-members' );?></label>
 						<input type="text" id="seats" name="seats" value="<?php echo esc_attr( $seats ); ?>" size="10" />
 				<?php } else { ?>
-						<input type="hidden" name="seats" value="<?php echo esc_attr( $seats ); ?>" size="10" />
+						<input type="hidden" id="seats" name="seats" value="<?php echo esc_attr( $seats ); ?>" size="10" />
 				<?php } ?>
 
 				<?php
@@ -1109,8 +1109,8 @@ function pmprosm_pmpro_checkout_boxes()
 				jQuery(document).ready(function() {
 					var pmpro_base_level_is_free = <?php if(pmpro_isLevelFree($pmpro_level)) echo "true"; else echo "false";?>;
 					var seat_cost = <?php echo intval($pmprosm_values['seat_cost']);?>;
-					var min_seats = <?php if(!empty($pmprosm_values['min_seats'])) echo intval($pmprosm_values['min_seats']); else echo "0";?>;
-					var max_seats = <?php if(!empty($pmprosm_values['max_seats'])) echo intval($pmprosm_values['max_seats']); else echo "false";?>;
+					var min_seats = <?php if(!empty($pmprosm_values['min_seats'])) echo intval($pmprosm_values['min_seats']); elseif (!empty($pmprosm_values['seats'])) echo intval($pmprosm_values['seats']); else echo "0";?>;
+					var max_seats = <?php if(!empty($pmprosm_values['max_seats'])) echo intval($pmprosm_values['max_seats']); elseif (!empty($pmprosm_values['seats'])) echo intval($pmprosm_values['seats']); else echo "false";?>;
 
 					//update things when the # of seats changes
 					jQuery('#seats, input.old_sub_accounts_active').bind("change", function() { 

--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -868,7 +868,7 @@ function pmprosm_pmpro_checkout_boxes()
 		return;
 	}
 
-	$can_edit_seats = empty( $pmprosm_values['max_seats'] ) && empty( $pmprosm_values['min_seats'] );
+	$can_edit_seats = ! empty( $pmprosm_values['max_seats'] ) || ! empty( $pmprosm_values['min_seats'] );
 	$seat_cost = $pmprosm_values['seat_cost'];
 	$max_seats = empty( $pmprosm_values['max_seats'] ) ? null : $pmprosm_values['max_seats'];
 


### PR DESCRIPTION
Allow configurations where the number of seats is fixed
and cannot be edited by the user during checkout.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Use a fixed-seat config such as

```php
global $pmprosm_sponsored_account_levels;
$pmprosm_sponsored_account_levels = array(
	2 => array(
		'main_level_id' => 2,
		'sponsored_level_id' => array(1),
		'min_seats' => 5,
		'max_seats' => 5,
		'seats' => 5,
		'seat_cost' => 0,
		'sponsored_accounts_at_checkout'  => true,
	)
);
```

2. Visit the checkout page for the level
3. You should be able to create 5 test accounts and the box to edit the number of accounts will not be displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Allow account creation during checkout for fixed-seat configs
