### PR TITLE
remove "ifxed" class from child member table for frontend

### DIFF
--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -1063,20 +1063,20 @@ function pmprosm_pmpro_checkout_boxes() {
                         </div>
                         <?php if(!empty($pmprosm_values['children_get_name'])) { ?>
 							<label><?php echo esc_html__("First Name", "pmpro-sponsored-members");?></label>
-							<input type="text" name="add_sub_accounts_first_name[]" value="<?php echo esc_attr($child_first_name);?>" size="20" />
+							<input type="text" name="add_sub_accounts_first_name[]" value="<?php echo esc_attr($child_first_name);?>"  class="input pmpro_required" size="20" />
 							<br>
 							<label><?php echo esc_html__("Last Name", "pmpro-sponsored-members");?></label>
-							<input type="text" name="add_sub_accounts_last_name[]" value="<?php echo esc_attr($child_last_name);?>" size="20" />
+							<input type="text" name="add_sub_accounts_last_name[]" value="<?php echo esc_attr($child_last_name);?>"  class="input pmpro_required" size="20" />
 							<br>
 						<?php } ?>
 						<?php if(empty($pmprosm_values['children_hide_username'])) { ?>
 							<label><?php echo esc_html__("Username", "pmpro-sponsored-members");?></label>
-							<input type="text" name="add_sub_accounts_username[]" value="<?php echo esc_attr($child_username);?>" size="20" />
+							<input type="text" name="add_sub_accounts_username[]" value="<?php echo esc_attr($child_username);?>"  class="input pmpro_required" size="20" />
 							<br>
 						<?php } ?>
 						<?php if(empty($pmprosm_values['children_hide_email'])) { ?>
 							<label><?php echo esc_html__("Email", "pmpro-sponsored-members");?></label>
-							<input type="text" name="add_sub_accounts_email[]" value="<?php echo esc_attr($child_email);?>" size="20" />
+							<input type="text" name="add_sub_accounts_email[]" value="<?php echo esc_attr($child_email);?>" class="input pmpro_required" size="20" />
 							<br>
 						<?php } ?>
 						<?php if(empty($pmprosm_values['children_hide_password'])) { ?>
@@ -1165,7 +1165,7 @@ function pmprosm_pmpro_checkout_boxes() {
 									i = children.length;
 
 									while (i < newseats) {
-                                        var div = '<div id="sponsored_account_'+i+'"><hr /><div><h3><?php echo esc_html( $sponsored_level->name ); esc_html_e(" account information # XXXX", 'pmpro-sponsored-members'); ?> </h3><h4><?php if (isset($pmprosm_values["sponsored_header_text"]))echo $pmprosm_values["sponsored_header_text"];else esc_html_e("Please fill in following information and account(s) will be created.", 'pmpro-sponsored-members');?></h4></div><?php if(!empty($pmprosm_values["children_get_name"])) { ?><label>First Name</label><input type="text" name="add_sub_accounts_first_name[]" value="" size="20" /><br><label>Last Name</label><input type="text" name="add_sub_accounts_last_name[]" value="" size="20" /><br><?php } ?><?php if(empty($pmprosm_values["children_hide_username"])){ ?><label>Username</label><input type="text" name="add_sub_accounts_username[]" value="" size="20" /><br><?php } ?><label>Email</label><input type="text" name="add_sub_accounts_email[]" value"" size="20" /><br><label>Password</label><input type="password" name="add_sub_accounts_password[]" value="" size="20" /><?php echo $empty_child_fields;?></div>';
+                                        var div = '<div id="sponsored_account_'+i+'"><hr /><div><h3><?php echo esc_html( $sponsored_level->name ); esc_html_e(" account information # XXXX", 'pmpro-sponsored-members'); ?> </h3><h4><?php if (isset($pmprosm_values["sponsored_header_text"]))echo $pmprosm_values["sponsored_header_text"];else esc_html_e("Please fill in following information and account(s) will be created.", 'pmpro-sponsored-members');?></h4></div><?php if(!empty($pmprosm_values["children_get_name"])) { ?><label>First Name</label><input type="text" name="add_sub_accounts_first_name[]" value="" class="input pmpro_required" size="20" /><br><label>Last Name</label><input type="text" name="add_sub_accounts_last_name[]" value="" class="input pmpro_required" size="20" /><br><?php } ?><?php if(empty($pmprosm_values["children_hide_username"])){ ?><label>Username</label><input type="text" name="add_sub_accounts_username[]" value="" class="input pmpro_required" size="20" /><br><?php } ?><label>Email</label><input type="text" name="add_sub_accounts_email[]" value"" class="input pmpro_required" size="20" /><br><label>Password</label><input type="password" name="add_sub_accounts_password[]" value="" class="input pmpro_required" size="20" /><?php echo $empty_child_fields;?></div>';
                                         newdiv = div.replace(/XXXX/g,i+1);
                                         jQuery('#sponsored_accounts').append(newdiv); i++;
 									}

--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -1805,7 +1805,7 @@ function pmprosm_display_sponsored_accounts( $member_ids ) {
 
     <h3><?php esc_html_e( "Sponsored Members", "pmpro-sponsored-members" );?></h3>
     <div class="pmpro-sponsored-members_children" <?php if( count( $member_ids ) > 4 ) { ?>style="height: 150px; overflow: auto;"<?php } ?>>
-        <table class="wp-list-table widefat fixed" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <table class="wp-list-table widefat" width="100%" cellpadding="0" cellspacing="0" border="0">
             <thead>
             <tr>
                 <th><?php esc_html_e( 'Date', 'pmpro-sponsored-members' ); ?></th>

--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -1853,7 +1853,7 @@ function pmprosm_display_sponsored_accounts( $member_ids ) {
 				$remove_url = wp_nonce_url( $remove_url, 'pmprosm_remove_member' );
 				?>
                 <tr<?php if($count++ % 2 == 1) { ?> class="alternate"<?php } ?>>
-                    <td><?php echo date(get_option("date_format"), $member->membership_level->startdate); ?></td>
+                    <td><?php echo date_i18n( get_option( 'date_format' ), $member->membership_level->startdate); ?></td>
                     <td><?php echo esc_html( $member->display_name ); ?></td>
                     <td>
 						<?php if ( current_user_can( 'edit_users' ) ) { ?>

--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -21,7 +21,7 @@ Domain Path: /languages
 		//set 5 seats at checkout
 		1 => array(
 			'main_level_id' => 1,		//redundant but useful
-			'sponsored_level_id' => array(1,2),	//array or single id
+			'sponsored_level_id' => array(2,3),	//array or single id
 			'seats' => 5
 		),
 		//seats based on field at checkout


### PR DESCRIPTION
Removed "fixed" class from Sponsored Members.  Themes that use .fixed can hide or change our table view on the frontend.
Updated formating of Startdate so it would translate month. 

### Prolem:

When a theme defines the .fixed class, it was hiding the table from our user.
.fixed should only be applied to admin tables, but this table is being used on the front and backend.

Tested in the admin area and changed column spacing only slightly.