### PR TITLE
Now removing child memberships if parent switches to non-sponsor

### DIFF
--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -152,27 +152,7 @@ function pmprosm_getValuesBySponsoredLevel( $level_id, $first = true ) {
 function pmprosm_pmpro_after_change_membership_level( $level_id, $user_id ) {
 	global $wpdb;
 
-	//are they cancelling?
-	if( empty( $level_id ) ) {
-		//is there a discount code attached to this user?
-		$code_id = pmprosm_getCodeByUserID( $user_id );
-
-		//if so find all users who signed up with that and cancel them as well
-		if( ! empty( $code_id ) ) {
-			$sqlQuery = "SELECT user_id FROM $wpdb->pmpro_discount_codes_uses WHERE code_id = '" . esc_sql( $code_id ) . "'";
-			$sub_user_ids = $wpdb->get_col($sqlQuery);
-
-			if( ! empty( $sub_user_ids ) ) {
-				foreach( $sub_user_ids as $sub_user_id ) {
-					//cancel their membership
-					pmpro_changeMembershipLevel( 0, $sub_user_id );
-				}
-			}
-		}
-
-		//remove seats from meta
-		update_user_meta( $user_id, 'pmprosm_seats', '' );
-	} elseif ( pmprosm_isMainLevel( $level_id ) ) {
+	if ( pmprosm_isMainLevel( $level_id ) ) { // Changing to a sponsoring level.
 		//get values for this sponsorship
 		$pmprosm_values = pmprosm_getValuesByMainLevel( $level_id );
 
@@ -218,7 +198,26 @@ function pmprosm_pmpro_after_change_membership_level( $level_id, $user_id ) {
 			//make sure we only do it once
 			remove_action( 'pmpro_after_checkout', 'pmprosm_pmpro_after_checkout_sponsor_account_change', 10, 2 );
 		}
-	}
+	} else { // They are cancelling or changing to a non-sponsor level.
+		//is there a discount code attached to this user?
+		$code_id = pmprosm_getCodeByUserID( $user_id );
+
+		//if so find all users who signed up with that and cancel them as well
+		if( ! empty( $code_id ) ) {
+			$sqlQuery = "SELECT user_id FROM $wpdb->pmpro_discount_codes_uses WHERE code_id = '" . esc_sql( $code_id ) . "'";
+			$sub_user_ids = $wpdb->get_col($sqlQuery);
+
+			if( ! empty( $sub_user_ids ) ) {
+				foreach( $sub_user_ids as $sub_user_id ) {
+					//cancel their membership
+					pmpro_changeMembershipLevel( 0, $sub_user_id );
+				}
+			}
+		}
+
+		//remove seats from meta
+		update_user_meta( $user_id, 'pmprosm_seats', '' );
+	} 
 }
 add_action( 'pmpro_after_change_membership_level', 'pmprosm_pmpro_after_change_membership_level', 10, 2 );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes exploit where sponsors could switch membership levels to a non-sponsor level to pay different fee without losing child accounts.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #96 .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
