### PR TITLE
remove fixed class

### DIFF
--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -1805,7 +1805,7 @@ function pmprosm_display_sponsored_accounts( $member_ids ) {
 
     <h3><?php esc_html_e( "Sponsored Members", "pmpro-sponsored-members" );?></h3>
     <div class="pmpro-sponsored-members_children" <?php if( count( $member_ids ) > 4 ) { ?>style="height: 150px; overflow: auto;"<?php } ?>>
-        <table class="wp-list-table widefat fixed" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <table class="wp-list-table widefat" width="100%" cellpadding="0" cellspacing="0" border="0">
             <thead>
             <tr>
                 <th><?php esc_html_e( 'Date', 'pmpro-sponsored-members' ); ?></th>

--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -1805,7 +1805,7 @@ function pmprosm_display_sponsored_accounts( $member_ids ) {
 
     <h3><?php esc_html_e( "Sponsored Members", "pmpro-sponsored-members" );?></h3>
     <div class="pmpro-sponsored-members_children" <?php if( count( $member_ids ) > 4 ) { ?>style="height: 150px; overflow: auto;"<?php } ?>>
-        <table class="wp-list-table widefat" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <table class="wp-list-table widefat striped" width="100%" cellpadding="0" cellspacing="0" border="0">
             <thead>
             <tr>
                 <th><?php esc_html_e( 'Date', 'pmpro-sponsored-members' ); ?></th>


### PR DESCRIPTION
Removed "fixed" class from Sponsored Members. Themes that use .fixed can hide or change our tables view on the frontend. 

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

Remove this class so themes that use the .fixed class will not control this table view.


