### PR TITLE
Fixes a PHP error on the Confirmation Page

### DIFF
--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -609,6 +609,10 @@ function pmprosm_pmpro_confirmation_message( $message ) {
 		$pmprosm_values = pmprosm_getValuesByMainLevel( $current_user->membership_level->ID );
 		$code = pmprosm_getDiscountCodeByCodeID( $code_id );
 
+		if( empty( $pmprosm_values['sponsored_level_id'] ) ) {
+			return $message;
+		}
+
 		if( ! is_array($pmprosm_values['sponsored_level_id'] ) ) {
 			$sponsored_level_ids = array($pmprosm_values['sponsored_level_id']);
 		} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes an error on the confirmation page

### How to test the changes in this Pull Request:

1. Signup for a level and get a sub account to sign up for one of the levels from the sponsored member
2. Get the main account to checkout with a free level with the sponsored account is still active
3. No errors should be present on the confirmation page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixes a PHP error on the Membership Confirmation page. 
