### PR TITLE
Fixes a PHP Error when changing levels

### DIFF
--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -339,7 +339,7 @@ function pmprosm_sponsored_account_change( $level_id, $user_id ) {
 			$old_sub_accounts_active = $_REQUEST['old_sub_accounts_active'];
 
 			for( $i = 0; $i < count( $children ); $i++ ) {
-				if( in_array( $children[$i], $old_sub_accounts_active ) ) {
+				if( is_array( $old_sub_accounts_active ) && in_array( $children[$i], $old_sub_accounts_active ) ) {
 					//they should have their level/etc from before
 				} else {
 					//remove their level


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes an error when changing levels. 

Resolves #110

### How to test the changes in this Pull Request:

Unable to replicate the error so working on a 'logical' fix around this for now.

I don't think this is PHP Version related, just that the $old_sub_accounts_active was not an array when it was expecting there to be one for some reason. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixes a PHP error on the Membership Confirmation page. 
