### PR TITLE
Better handling of plurals on confirmation page

### DIFF
--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -647,7 +647,7 @@ function pmprosm_pmpro_confirmation_message( $message ) {
 			if ( empty( $code->uses ) ) {
 				$message .= __( "This code has unlimited uses.", "pmpro-sponsored-members" );
 			} else {
-				$message .= sprintf( ngettext( __( "This code has %d use.", "pmpro-sponsored-members" ), __( "This code has %d uses.", "pmpro-sponsored-members" ), $code->uses ), $code->uses );
+				$message .= sprintf( _n( 'This code has %d use.', 'This code has %d uses.', $code->uses, 'pmpro-sponsored-members' ), $code->uses );
 			}
 
 			$message .= "</div>";


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Better handling of the word 'uses' when a discount code only has 1 'use'

Resolves #95

### How to test the changes in this Pull Request:

1. Set discount code uses to only 1
2. Purchase a Sponsored Members level
3. The code displayed on the Confirmation page will show as 'This code has 1 use.' instead of 'This code has 1 uses'.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Better handling of plurals in some language on the confirmation page
