### PR TITLE
Fixes cases where the current user shows as the sponsored member for a parent

### DIFF
--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -500,19 +500,22 @@ function pmprosm_getChildren( $user_id = NULL ) {
 
     $code_id = pmprosm_getCodeByUserID( $user_id );
 
-    if( ! empty( $code_id ) ) {
-		$children = $wpdb->get_col("SELECT user_id FROM $wpdb->pmpro_memberships_users WHERE code_id = '" . esc_sql( $code_id ) . "' AND status = 'active'");
+	if( empty( $code_id ) ) {
+		return false;
 	}
+
+	$children = $wpdb->get_col("SELECT user_id FROM $wpdb->pmpro_memberships_users WHERE code_id = '" . esc_sql( $code_id ) . "' AND status = 'active'");
 
 	// If sponsor account is expired or cancelled,
 	// then children accounts are no longer active.
 	// So we can get a list of old children accounts
 	// by getting all the uses of the discount code.
 
-	if ( empty( $children ) && ! empty( $code_id ) ) {
+	if ( empty( $children ) ) {
 		$sqlQuery = "SELECT user_id FROM $wpdb->pmpro_discount_codes_uses WHERE code_id = '" . esc_sql( $code_id ) . "'";
 		$children = $wpdb->get_col( $sqlQuery );
 	}
+	
     return $children;
 }
 

--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -509,7 +509,7 @@ function pmprosm_getChildren( $user_id = NULL ) {
 	// So we can get a list of old children accounts
 	// by getting all the uses of the discount code.
 
-	if ( empty( $children ) ) {
+	if ( empty( $children ) && ! empty( $code_id ) ) {
 		$sqlQuery = "SELECT user_id FROM $wpdb->pmpro_discount_codes_uses WHERE code_id = '" . esc_sql( $code_id ) . "'";
 		$children = $wpdb->get_col( $sqlQuery );
 	}


### PR DESCRIPTION
When editing a sponsored member account where no discount code has been created for them, a list shows of the current user that may have created a discount code in the past but didn't use it. 

This appears to have been caused by the discount code ID being empty, and still running a query to get discount codes, which then provides false results that don't belong with that user. 

The fix for this comes from ticket #485557 mods only