### PR TITLE
BUG FIX: seat_cost showing $0 when set.

### DIFF
--- a/pmpro-sponsored-members.php
+++ b/pmpro-sponsored-members.php
@@ -940,7 +940,8 @@ function pmprosm_pmpro_checkout_boxes() {
 									if ( isset( $pmprosm_values['seat_cost_text'] ) ) {
 										printf( esc_html__( "Enter a number from %d to %d. %s", "pmpro-sponsored-members" ), $min_seats, $pmprosm_values['max_seats'], $pmprosm_values['seat_cost_text'] );
 									} else {
-										printf( esc_html__( "Enter a number from %d to %d. +%s per extra seat.", "pmpro-sponsored-members" ), $min_seats, $pmprosm_values['max_seats'], $pmpro_currency_symbol . empty( $pmprosm_values['seat_cost'] ) ? 0 : $pmprosm_values['seat_cost'] );
+										$seat_cost = empty( $pmprosm_values['seat_cost'] ) ? 0 : $pmprosm_values['seat_cost'];
+										printf( esc_html__( "Enter a number from %d to %d. +%s per extra seat.", "pmpro-sponsored-members" ), $min_seats, $pmprosm_values['max_seats'], $pmpro_currency_symbol . $seat_cost );									
 									}
 								}
 							?>


### PR DESCRIPTION
BUG FIX: Fixed an issue where seat_cost would show 0 for non-zero values.

Resolves: https://github.com/strangerstudios/pmpro-sponsored-members/issues/129

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?